### PR TITLE
Fix "ShrinkCompiler not found"

### DIFF
--- a/src/Lib/Shrink.php
+++ b/src/Lib/Shrink.php
@@ -125,7 +125,7 @@ class Shrink{
 			$output = '';
 
 			foreach($files as $k=>$v){
-				$lang = $v['file']->ext();
+				$lang = substr($v['file']->name, strrpos($v['file']->name, '.') + 1);
 
 				// load compiler if it is not already
 				if(!isset($this->compilers[$lang])){


### PR DESCRIPTION
I have this error : Error: Class 'Shrink\Lib\ShrinkCompiler\ShrinkCompiler' not found
This work around fix it.
see : https://github.com/trentrichardson/cakephp-shrink/issues/7